### PR TITLE
Add file-based persistence for study tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "break_forgeting_curve",
+  "version": "1.0.0",
+  "description": "This project is designed to help users combat the Forgetting Curve by utilizing spaced repetition techniques for effective learning.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"No tests specified\" && exit 0"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/scripts.js
+++ b/scripts.js
@@ -51,6 +51,34 @@ document.addEventListener('DOMContentLoaded', () => {
     // Spaced Repetition Data Storage
     const taskData = {}; // Store task info and review dates
 
+    // Load tasks from persistent storage
+    fetch('/tasks')
+        .then(response => response.json())
+        .then(savedTasks => {
+            savedTasks.forEach(info => {
+                const li = document.createElement('li');
+                li.textContent = info.task;
+                todoList.appendChild(li);
+
+                taskData[info.task] = {
+                    lastReviewed: new Date(info.lastReviewed),
+                    interval: info.interval,
+                    retention: info.retention
+                };
+
+                progressChart.data.labels.push(formatDate(new Date(info.lastReviewed)));
+                progressChart.data.datasets[0].data.push(info.retention);
+
+                calendar.addEvent({
+                    title: info.task,
+                    start: new Date(info.lastReviewed).toISOString().split('T')[0],
+                    allDay: true
+                });
+            });
+            progressChart.update();
+        })
+        .catch(err => console.error('Error loading tasks:', err));
+
     // Add a new task
     todoForm.addEventListener('submit', (e) => {
         e.preventDefault();
@@ -80,12 +108,30 @@ document.addEventListener('DOMContentLoaded', () => {
             });
 
             taskInput.value = '';
+            saveTasksToServer();
         }
     });
 
     // Function to format date as YYYY-MM-DD
     function formatDate(date) {
         return date.toISOString().split('T')[0];
+    }
+
+    function saveTasksToServer() {
+        const tasks = Object.keys(taskData).map(task => ({
+            task: task,
+            lastReviewed: taskData[task].lastReviewed,
+            interval: taskData[task].interval,
+            retention: taskData[task].retention
+        }));
+
+        fetch('/tasks', {
+            method: 'PUT',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(tasks)
+        }).catch(err => console.error('Error saving tasks:', err));
     }
 
     // Function to update retention and set next review
@@ -116,6 +162,7 @@ document.addEventListener('DOMContentLoaded', () => {
         taskInfo.retention = 90; // Reset retention to 90% after review
         progressChart.data.datasets[0].data.push(taskInfo.retention);
         progressChart.update();
+        saveTasksToServer();
     }
 
     // Example of adding repetition for demo purpose
@@ -145,6 +192,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (chartUpdated) {
             progressChart.update();
+            saveTasksToServer();
         }
     }, 10000); // Update retention and date every 10 seconds for demo purposes
 });

--- a/server.js
+++ b/server.js
@@ -1,0 +1,86 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const url = require('url');
+
+const dataDir = path.join(os.homedir(), 'gestor', 'system', 'cronograma');
+const dataFile = path.join(dataDir, 'tasks.json');
+fs.mkdirSync(dataDir, { recursive: true });
+
+function loadTasks() {
+  try {
+    const data = fs.readFileSync(dataFile, 'utf-8');
+    return JSON.parse(data);
+  } catch {
+    return [];
+  }
+}
+
+function saveTasks(tasks) {
+  fs.writeFileSync(dataFile, JSON.stringify(tasks, null, 2));
+}
+
+function serveStatic(filePath, contentType, res) {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(500);
+      res.end('Server error');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(data);
+  });
+}
+
+const server = http.createServer((req, res) => {
+  const parsedUrl = url.parse(req.url, true);
+
+  if (req.method === 'GET' && parsedUrl.pathname === '/tasks') {
+    const tasks = loadTasks();
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(tasks));
+    return;
+  }
+
+  if (req.method === 'PUT' && parsedUrl.pathname === '/tasks') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      try {
+        const tasks = JSON.parse(body);
+        if (!Array.isArray(tasks)) throw new Error('Array required');
+        saveTasks(tasks);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ message: 'Tasks saved' }));
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: err.message }));
+      }
+    });
+    return;
+  }
+
+  if (req.method === 'GET' && (parsedUrl.pathname === '/' || parsedUrl.pathname === '/index.html')) {
+    serveStatic(path.join(__dirname, 'index.html'), 'text/html', res);
+    return;
+  }
+
+  if (req.method === 'GET' && parsedUrl.pathname === '/scripts.js') {
+    serveStatic(path.join(__dirname, 'scripts.js'), 'application/javascript', res);
+    return;
+  }
+
+  if (req.method === 'GET' && parsedUrl.pathname === '/styles.css') {
+    serveStatic(path.join(__dirname, 'styles.css'), 'text/css', res);
+    return;
+  }
+
+  res.writeHead(404);
+  res.end('Not found');
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- Implement simple Node.js HTTP server saving tasks under `~/gestor/system/cronograma`
- Load persisted tasks in the client and synchronize changes back to the server
- Add package configuration with start and test scripts

## Testing
- `npm test`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_689b31ec23148330a5ba2b01f74ba89e